### PR TITLE
Fix for error "Can't find variable `msg`"

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -83,7 +83,7 @@ export class DragulaService {
       let errMsg = `Drake named: "${name}" already exists for this service [${this.name}]. 
       Most likely this error in cause by a race condition evaluating multiple template elements with 
       the v-dragula directive having the same drake name. Please initialise the drake in the created() life cycle hook of the VM to fix this problem.`
-      this.error(msg)
+      this.error(errMsg)
     }
 
     this.drakes[name] = drake


### PR DESCRIPTION
If any error should occur the message is not reported correctly: the name of the variable containing the error message was mistyped.