### PR TITLE
Add mandatory :key attribute to README template

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ Vue.use(Vue2Dragula, {
 <div class="wrapper">
   <div class="container" v-dragula="colOne" drake="first">
     <!-- with click -->
-    <div v-for="text in colOne" @click="onClick">{{text}} [click me]</div>
+    <div v-for="text in colOne" :key="text" @click="onClick">{{text}} [click me]</div>
   </div>
   <div class="container" v-dragula="colTwo" drake="first">
-    <div v-for="text in colTwo">{{text}}</div>
+    <div v-for="text in colTwo" :key="text">{{text}}</div>
   </div>
 </div>
 ```
+
+**NOTE**: Since Vue 2.x, having the `:key` attribute when using `v-for` is **reqired**.
 
 ## API
 You can access the global app service via `Vue.$dragula.$service` or from within a component via `this.$dragula.$service`.


### PR DESCRIPTION
I previous opened issue #12, but turns out it's a simple oversight. I had followed the example template in the README and being new to Vue, did not realize that `:key` was mandatory. I'm adding this to the README so that others that are new to Vue won't spend hours trying to debug such a simple issue...