### PR TITLE
Update README to mention importing of dragula CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Vue.use(Vue2Dragula, {
 });
 ```
 
+[Dragula's CSS](https://github.com/bevacqua/dragula/blob/master/dist/dragula.css), which provides visual feedback for drag effects, is not included in this package and must be imported or provided in your app.
+
+```js
+import 'dragula/dist/dragula.css'
+```
+
 ## Documentation
 
 For additional documentation, see the [docs folder](https://github.com/kristianmandrup/vue2-dragula/tree/master/docs)


### PR DESCRIPTION
The package by itself doesn't provide the expected visual feedback that one may assume after using the demo or reading the docs. It is a bit misleading because some classes and styles are applied through JS, which doesn't tip off that something may be missing or requires additional code. 

I was banging my head for a while until I pulled the vue2-dragula-demo down and noticed dragula's CSS being imported, so I wanted to add a note mentioning that users may want to import dragula's CSS or provide it in their code in some way.

On an unrelated note, I'd like to help clean-up/organize the README more in the future, but really wanted to get this note in the docs to help anyone else. I was just wondering if you'd be open to that.