### PR TITLE
Fix for the reactivity - drake.cancel(true) on successful drops to avoid inconsistent VirtualDOM

### DIFF
--- a/src/drag-handler.js
+++ b/src/drag-handler.js
@@ -117,9 +117,11 @@ export class DragHandler {
    * If not copy, we remove model from source model after a nice transition
    */
   notCopy() {
-    waitForTransition(() => {
+    // This transition poses a problem in dropModel handlers - because if we try to use the model 
+    // inside such a handler - the model has not been updated yet because of this waiting for transition 
+    //waitForTransition(() => {
       this.sourceModel.removeAt(this.dragIndex)
-    })
+    //})
   }
 
   /**
@@ -152,6 +154,11 @@ export class DragHandler {
     let targetModel = this.getModel(target)
     let dropElmModel = notCopy ? this.dropElmModel() : this.jsonDropElmModel()
 
+    // we have to cancel the drop to prevent discrepancy between VirtualDOM and actual DOM
+    // otherwise when we update the models and Vue tries to re-render it will be confused when not
+    // finding the dragged node where Vue expects to find it
+    this.drake.cancel(true); 
+    
     if (notCopy) {
       this.notCopy()
     }

--- a/src/model-manager.js
+++ b/src/model-manager.js
@@ -59,7 +59,7 @@ export class ModelManager extends BaseModelManager {
       splicedModel,
       removedModel
     })
-    return splicedModel
+    return removedModel
   }
 
   insertAt(index, insertModel) {

--- a/src/vue-dragula.js
+++ b/src/vue-dragula.js
@@ -249,16 +249,19 @@ export default function (Vue, options = {}) {
   function calcNames(name, vnode, ctx) {
     let drakeName = vnode ? vnode.data.attrs.drake : this.params.drake
     const serviceName = vnode ? vnode.data.attrs.service : this.params.service
+    let drakeOptions = vnode ? vnode.data.attrs.options : this.params.options
 
     if (drakeName !== undefined && drakeName.length !== 0) {
       name = drakeName
     }
     drakeName = isEmpty(drakeName) ? 'default' : drakeName
+    if (!drakeOptions) drakeOptions = {}
 
     return {
       name,
       drakeName,
-      serviceName
+      serviceName,
+      drakeOptions
     }
   }
 
@@ -332,7 +335,7 @@ export default function (Vue, options = {}) {
   }
 
   Vue.directive('dragula', {
-    params: ['drake', 'service'],
+    params: ['drake', 'service', 'options'],
 
     bind(container, binding, vnode) {
       logDir('BIND', container, binding, vnode)
@@ -340,7 +343,8 @@ export default function (Vue, options = {}) {
       const {
         name,
         drakeName,
-        serviceName
+        serviceName,
+        drakeOptions
       } = calcNames(globalName, vnode, this)
       const service = findService(name, vnode, serviceName)
       const drake = service.find(drakeName, vnode)
@@ -365,9 +369,8 @@ export default function (Vue, options = {}) {
         drake.containers.push(container)
         return
       }
-      let newDrake = dragula({
-        containers: [container]
-      })
+      drakeOptions.containers = [container]
+      let newDrake = dragula(drakeOptions)
       service.add(name, newDrake)
 
       service.handleModels(name, newDrake)


### PR DESCRIPTION
1) added ability to provide options object through an attribute on the component
2) got rid of the transition when removing an item from the model - it prevents the "dropModel" handler from accessing the new model (as the item has not been removed yet at this time)
3) when the item is successfully dropped - we should update the model(s) but we have to signal the drake to cancel the dragging - otherwise there will be a discrepancy between VirtualDOM and the real DOM and this confuses Vue